### PR TITLE
feature: [프론트 검색(비로그인)] 메인 달력 컴포넌트 #8

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "rules": {
       "react/prefer-stateless-function": 0,
       "react/jsx-filename-extension": 0,
-      "react/jsx-one-expression-per-line": 0
+      "react/jsx-one-expression-per-line": 0,
+      "react/prop-types": 0 
     },
     "env": {
       "browser": true

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^12.1.10",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^7.2.0",
+    "moment": "^2.29.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",

--- a/src/component/calander.jsx
+++ b/src/component/calander.jsx
@@ -1,9 +1,0 @@
-import React, { Component } from 'react';
-
-class Calander extends Component {
-  render() {
-    return <div>력달</div>;
-  }
-}
-
-export default Calander;

--- a/src/component/calendar.jsx
+++ b/src/component/calendar.jsx
@@ -11,25 +11,25 @@ class Calendar extends Component {
     };
   }
 
+  getWeek = (firstWeek, lastWeek, day) => {
+    let result = [];
+    let week = firstWeek;
+    for (week; week <= lastWeek; week += 1) {
+      result = result.concat(<CalendarWeek key={week} week={week} day={day} />);
+    }
+
+    return result;
+  };
+
   render() {
     const { today } = this.state;
+    const day = today;
     const firstWeek = today.clone().startOf('month').week();
     const lastWeek =
       today.clone().endOf('month').week() === 1
         ? 53
         : today.clone().endOf('month').week();
-
-    const getWeek = () => {
-      let result = [];
-      let week = firstWeek;
-      for (week; week <= lastWeek; week += 1) {
-        result = result.concat(
-          <CalendarWeek key={week} week={week} today={today} />,
-        );
-      }
-
-      return result;
-    };
+    const result = this.getWeek(firstWeek, lastWeek, day);
 
     return (
       <div className={style.calendarWrap}>
@@ -37,24 +37,24 @@ class Calendar extends Component {
           <button
             type="button"
             onClick={() => {
-              const momentUpper = today.clone().subtract(1, 'month');
+              const momentUpper = day.clone().subtract(1, 'month');
               this.setState({ today: momentUpper });
             }}
           >
             이전 달
           </button>
-          {today.format('YY-MM')}
+          {day.format('YY-MM')}
           <button
             type="button"
             onClick={() => {
-              const momentLower = today.clone().add(1, 'month');
+              const momentLower = day.clone().add(1, 'month');
               this.setState({ today: momentLower });
             }}
           >
             다음 달
           </button>
         </div>
-        <div className={style.calendar}>{getWeek()}</div>
+        <div className={style.calendar}>{result}</div>
       </div>
     );
   }

--- a/src/component/calendar.jsx
+++ b/src/component/calendar.jsx
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import moment from 'moment';
+import CalendarWeek from './calendar_week';
+import style from '../css/calendar.module.css';
+
+class Calendar extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      today: moment(),
+    };
+  }
+
+  render() {
+    const { today } = this.state;
+    const firstWeek = today.clone().startOf('month').week();
+    const lastWeek =
+      today.clone().endOf('month').week() === 1
+        ? 53
+        : today.clone().endOf('month').week();
+
+    const getWeek = () => {
+      let result = [];
+      let week = firstWeek;
+      for (week; week <= lastWeek; week += 1) {
+        result = result.concat(
+          <CalendarWeek key={week} week={week} today={today} />,
+        );
+      }
+
+      return result;
+    };
+
+    return (
+      <div className={style.calendarWrap}>
+        <div className={style.calendarHeader}>
+          <button
+            type="button"
+            onClick={() => {
+              const momentUpper = today.clone().subtract(1, 'month');
+              this.setState({ today: momentUpper });
+            }}
+          >
+            이전 달
+          </button>
+          {today.format('YY-MM')}
+          <button
+            type="button"
+            onClick={() => {
+              const momentLower = today.clone().add(1, 'month');
+              this.setState({ today: momentLower });
+            }}
+          >
+            다음 달
+          </button>
+        </div>
+        <div className={style.calendar}>{getWeek()}</div>
+      </div>
+    );
+  }
+}
+
+export default Calendar;

--- a/src/component/calendar_day.jsx
+++ b/src/component/calendar_day.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import '../css/calander_day.css';
+
+const CalendarDay = (props) => {
+  //   const onDragOver = (event) => {
+  //     event.preventDefault();
+  //   };
+
+  //   const onDrop = (event) => {
+  //     const id = event.dataTransfer.getData('text');
+  //     const companyDataElement = document.querySelector(`[data-id='${id}']`);
+  //     const companyData = document.createElement('li');
+  //     const dropZone = event.currentTarget;
+  //     const dropZoneList = dropZone.querySelector('ul');
+  //     // console.log(companyDataElement);
+  //     console.log(dropZoneList);
+  //     companyData.innerText = companyDataElement.innerText;
+  //     dropZoneList.appendChild(companyData);
+
+  //     event.dataTransfer.clearData();
+  //     companyDataElement.style.backgroundColor = 'cornsilk';
+  //   };
+
+  const { className } = props;
+  const { day } = props;
+
+  return (
+    <div className={className}>
+      {day}
+      {/* <ul className="calendar-day-company-list" /> */}
+    </div>
+  );
+};
+
+export default CalendarDay;

--- a/src/component/calendar_week.jsx
+++ b/src/component/calendar_week.jsx
@@ -1,21 +1,15 @@
-import React, { Component } from 'react';
+import React from 'react';
 import style from '../css/calendar.module.css';
 
-class CalendarWeek extends Component {
-  render() {
-    // const getDay = () =>
-    //   Array(7)
-    //     .fill(0)
-    //     .map((data, index) => {
-    //       let day = this.props.today
-    //         .clone()
-    //         .startOf('year')
-    //         .week(this.props.week)
-    //         .startOf('week')
-    //         .add(index, 'day');
-    //     });
-    return <div className={style.calendarWeek}>하이</div>;
-  }
-}
+const CalendarWeek = (props) => {
+  const a = 324;
+  const { week } = props;
+  return (
+    <div className={style.calendarWeek}>
+      하이{a}
+      {week}
+    </div>
+  );
+};
 
 export default CalendarWeek;

--- a/src/component/calendar_week.jsx
+++ b/src/component/calendar_week.jsx
@@ -1,15 +1,58 @@
 import React from 'react';
+import moment from 'moment';
 import style from '../css/calendar.module.css';
+import CalendarDay from './calendar_day';
 
-const CalendarWeek = (props) => {
-  const a = 324;
-  const { week } = props;
-  return (
-    <div className={style.calendarWeek}>
-      하이{a}
-      {week}
-    </div>
-  );
+const getDay = (props) => {
+  const { day } = props;
+  return Array(7)
+    .fill(0)
+    .map((data, index) => {
+      const days = day
+        .clone()
+        .startOf('year')
+        .week(props.week)
+        .startOf('week')
+        .add(index, 'day');
+
+      if (moment().format('YYYYMMDD') === days.format('YYYYMMDD')) {
+        let className = `calendarDay calendarDayToday`;
+        if (index === 0) {
+          className += ' red';
+        } else if (index === 6) {
+          className += ' blue';
+        }
+        return (
+          <CalendarDay
+            key={days}
+            day={days.format('D')}
+            className={className}
+          />
+        );
+      }
+      if (days.format('MM') !== props.day.format('MM')) {
+        return (
+          <CalendarDay
+            key={days}
+            day={days.format('D')}
+            className="calendarDay calendarDayNotThisMonth"
+          />
+        );
+      }
+      let className = `calendarDay`;
+      if (index === 0) {
+        className += ' red';
+      } else if (index === 6) {
+        className += ' blue';
+      }
+      return (
+        <CalendarDay key={days} day={days.format('D')} className={className} />
+      );
+    });
 };
+
+const CalendarWeek = (props) => (
+  <div className={style.calendarWeek}>{getDay(props)}</div>
+);
 
 export default CalendarWeek;

--- a/src/component/calendar_week.jsx
+++ b/src/component/calendar_week.jsx
@@ -1,0 +1,21 @@
+import React, { Component } from 'react';
+import style from '../css/calendar.module.css';
+
+class CalendarWeek extends Component {
+  render() {
+    // const getDay = () =>
+    //   Array(7)
+    //     .fill(0)
+    //     .map((data, index) => {
+    //       let day = this.props.today
+    //         .clone()
+    //         .startOf('year')
+    //         .week(this.props.week)
+    //         .startOf('week')
+    //         .add(index, 'day');
+    //     });
+    return <div className={style.calendarWeek}>하이</div>;
+  }
+}
+
+export default CalendarWeek;

--- a/src/component/main.jsx
+++ b/src/component/main.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Calander from './calander';
+import Calendar from './calendar';
 import JobOpening from './job_opening';
 import Search from './search';
 import style from '../css/main.module.css';
@@ -9,7 +9,7 @@ class Main extends Component {
     return (
       <main className={style.main}>
         <Search />
-        <Calander />
+        <Calendar />
         <JobOpening />
       </main>
     );

--- a/src/css/calander_day.css
+++ b/src/css/calander_day.css
@@ -1,0 +1,30 @@
+.calendarDay {
+  width: 14.285%;
+  height: 100%;
+  background-color: #f6f5f5;
+  border-left: 2px solid #d3e0ea;
+  border-right: 2px solid #d3e0ea;
+  display: flex;
+  flex-direction: column;
+}
+
+.calendarDay:nth-child(even) {
+  border-left: none;
+  border-right: none;
+}
+
+.calendarDay.red {
+  color: red;
+}
+
+.calendarDay.blue {
+  color: blue;
+}
+
+.calendarDayToday {
+  background-color: #bbdfc8;
+}
+
+.calendarDayNotThisMonth {
+  background-color: #bbbbbb;
+}

--- a/src/css/calendar.module.css
+++ b/src/css/calendar.module.css
@@ -16,7 +16,8 @@
   justify-content: center;
   align-items: center;
   height: 40px;
-  background-color: darkcyan;
+  background-color: #ece2e1;
+  border-bottom: 2px solid #d3e0ea;
 }
 
 .calendarHeader button {
@@ -24,5 +25,15 @@
 }
 
 .calendarWeek {
-  height: 120px;
+  height: 100px;
+  border-bottom: 2px solid #d3e0ea;
+}
+
+.calendar {
+  display: flex;
+  flex-direction: column;
+}
+
+.calendarWeek {
+  display: flex;
 }

--- a/src/css/calendar.module.css
+++ b/src/css/calendar.module.css
@@ -1,0 +1,28 @@
+.calendarWrap {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 0;
+}
+
+.calendarHeader,
+.calendar {
+  width: 50%;
+}
+
+.calendarHeader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 40px;
+  background-color: darkcyan;
+}
+
+.calendarHeader button {
+  margin: 0 1rem;
+}
+
+.calendarWeek {
+  height: 120px;
+}


### PR DESCRIPTION
calendar -> calendarWeek -> calendarDay로 props가 내려가는 형태

css 스타일링이 calendarDay의 경우는 순수 css로만 되어 있는 형태
-> 추후 postcss로 전환이 필요하다

resloved #8 